### PR TITLE
Configurable AWS region, market orders

### DIFF
--- a/gdax_bot.py
+++ b/gdax_bot.py
@@ -14,158 +14,28 @@ import gdax
 
 from decimal import Decimal
 
+from gdax.public_client import PublicClient
+
 
 def get_timestamp():
     ts = time.time()
     return datetime.datetime.fromtimestamp(ts).strftime('%Y-%m-%d %H:%M:%S')
 
-
-"""
-    Basic Coinbase Pro DCA buy/sell bot that pulls the current market price, subtracts a
-        small spread to generate a valid price (see note below), then submits the trade as
-        a limit order.
-
-    This is meant to be run as a crontab to make regular buys/sells on a set schedule.
-"""
-parser = argparse.ArgumentParser(
-    description="""
-        This is a basic Coinbase Pro DCA buying/selling bot.
-
-        ex:
-            BTC-USD BUY 14 USD          (buy $14 worth of BTC)
-            BTC-USD BUY 0.00125 BTC     (buy 0.00125 BTC)
-            ETH-BTC SELL 0.00125 BTC    (sell 0.00125 BTC worth of ETH)
-            ETH-BTC SELL 0.1 ETH        (sell 0.1 ETH)
-    """,
-    formatter_class=argparse.RawTextHelpFormatter
-)
-
-# Required positional arguments
-parser.add_argument('market_name', help="(e.g. BTC-USD, ETH-BTC, etc)")
-
-parser.add_argument('order_side',
-                    type=str,
-                    choices=["BUY", "SELL"])
-
-parser.add_argument('amount',
-                    type=Decimal,
-                    help="The quantity to buy or sell in the amount_currency")
-
-parser.add_argument('amount_currency',
-                    help="The currency the amount is denominated in")
-
-
-# Additional options
-parser.add_argument('-sandbox',
-                    action="store_true",
-                    default=False,
-                    dest="sandbox_mode",
-                    help="Run against sandbox, skips user confirmation prompt")
-
-parser.add_argument('-warn_after',
-                    default=3600,
-                    action="store",
-                    type=int,
-                    dest="warn_after",
-                    help="secs to wait before sending an alert that an order isn't done")
-
-parser.add_argument('-j', '--job',
-                    action="store_true",
-                    default=False,
-                    dest="job_mode",
-                    help="Suppresses user confirmation prompt")
-
-parser.add_argument('-c', '--config',
-                    default="settings.conf",
-                    dest="config_file",
-                    help="Override default config file location")
-
-
-
-if __name__ == "__main__":
-    args = parser.parse_args()
-    print("%s: STARTED: %s" % (get_timestamp(), args))
-
-    market_name = args.market_name
-    order_side = args.order_side.lower()
-    amount = args.amount
-    amount_currency = args.amount_currency
-
-    sandbox_mode = args.sandbox_mode
-    job_mode = args.job_mode
-    warn_after = args.warn_after
-
-    if not sandbox_mode and not job_mode:
-        if sys.version_info[0] < 3:
-            # python2.x compatibility
-            response = raw_input("Production purchase! Confirm [Y]: ")  # noqa: F821
-        else:
-            response = input("Production purchase! Confirm [Y]: ")
-        if response != 'Y':
-            print("Exiting without submitting purchase.")
-            exit()
-
-    # Read settings
-    config = configparser.ConfigParser()
-    config.read(args.config_file)
-
-    config_section = 'production'
-    if sandbox_mode:
-        config_section = 'sandbox'
-    key = config.get(config_section, 'API_KEY')
-    passphrase = config.get(config_section, 'PASSPHRASE')
-    secret = config.get(config_section, 'SECRET_KEY')
-    aws_access_key_id = config.get(config_section, 'AWS_ACCESS_KEY_ID')
-    aws_secret_access_key = config.get(config_section, 'AWS_SECRET_ACCESS_KEY')
-    sns_topic = config.get(config_section, 'SNS_TOPIC')
-    aws_region = config.get(config_section, 'AWS_REGION')
-
-    # Instantiate public and auth API clients
-    if not args.sandbox_mode:
-        auth_client = gdax.AuthenticatedClient(key, secret, passphrase)
-    else:
-        # Use the sandbox API (requires a different set of API access credentials)
-        auth_client = gdax.AuthenticatedClient(
-            key,
-            secret,
-            passphrase,
-            api_url="https://api-public.sandbox.pro.coinbase.com")
-
-    public_client = gdax.PublicClient()
-
-    # Retrieve dict list of all trading pairs
-    products = public_client.get_products()
-    base_min_size = None
-    base_increment = None
-    quote_increment = None
-    for product in products:
-        if product.get("id") == market_name:
-            base_currency = product.get("base_currency")
-            quote_currency = product.get("quote_currency")
-            base_min_size = Decimal(product.get("base_min_size")).normalize()
-            base_increment = Decimal(product.get("base_increment")).normalize()
-            quote_increment = Decimal(product.get("quote_increment")).normalize()
-            if amount_currency == product.get("quote_currency"):
-                amount_currency_is_quote_currency = True
-            elif amount_currency == product.get("base_currency"):
-                amount_currency_is_quote_currency = False
-            else:
-                raise Exception("amount_currency %s not in market %s" % (amount_currency,
-                                                                         market_name))
-            print(product)
-
-    print("base_min_size: %s" % base_min_size)
-    print("quote_increment: %s" % quote_increment)
-
-    # Prep boto SNS client for email notifications
-    sns = boto3.client(
-        "sns",
-        aws_access_key_id=aws_access_key_id,
-        aws_secret_access_key=aws_secret_access_key,
-        region_name=aws_region
-    )
-
-
+def do_limit_order(
+    market_name: str,
+    public_client: PublicClient, 
+    auth_client: gdax.AuthenticatedClient,
+    sns, sns_topic: str,
+    amount_currency_is_quote_currency: bool,
+    order_side: str,
+    quote_increment,
+    quote_currency,
+    base_increment,
+    base_currency,
+    amount,
+    amount_currency,
+    warn_after
+):
     """
         Buy orders will be rejected if they are at or above the lowest sell order
           (think: too far right on the order book). When the price is plummeting
@@ -352,6 +222,300 @@ if __name__ == "__main__":
         Message=json.dumps(order, sort_keys=True, indent=4)
     )
 
+    return (order, offer_price)
+# end do_limit_order()
+
+def do_market_order(
+    order_side: str,
+    auth_client: gdax.AuthenticatedClient,
+    quote_currency_amount,
+    quote_currency,
+    market_name: str,
+    sns, sns_topic,
+    warn_after
+):
+    if order_side == "buy":
+        result = auth_client.buy(type='market',
+                                    funds=float(quote_currency_amount),  # quantity of base_currency to buy
+                                    product_id=market_name)
+    elif order_side == "sell":
+        result = auth_client.sell(type='market',
+                                    funds=float(quote_currency_amount),  # quantity of base_currency to buy
+                                    product_id=market_name)
+
+    print(json.dumps(result, sort_keys=True, indent=4))
+
+    if "message" in result:
+        # Something went wrong if there's a 'message' field in response
+        sns.publish(
+            TopicArn=sns_topic,
+            Subject="Could not place %s market %s order for %s %s" % (market_name,
+                                                                order_side,
+                                                                quote_currency_amount,
+                                                                quote_currency
+                                                                ),
+            Message=json.dumps(result, sort_keys=True, indent=4)
+        )
+        return
+
+    if result and "status" in result and result["status"] == "rejected":
+        # Rejected - usually because price was above lowest sell offer. Try
+        #   again in the next loop.
+        print("%s: %s market order rejected " % (get_timestamp(), market_name))
+        sns.publish(
+            TopicArn=sns_topic,
+            Subject="%s: %s market order rejected " % (get_timestamp(), market_name),
+            Message=json.dumps(result, sort_keys=True, indent=4)
+        )
+        return
+
+    order = result
+    order_id = order["id"]
+    print("order_id: " + order_id)
+
+
+    '''
+        Wait to see if the market order was fulfilled.
+    '''
+    wait_time = 60
+    total_wait_time = 0
+    while "status" in order and \
+            (order["status"] == "pending" or order["status"] == "open"):
+        if total_wait_time > warn_after:
+            sns.publish(
+                TopicArn=sns_topic,
+                Subject="%s %s market order for %s %s OPEN/UNFILLED" % (
+                    market_name,
+                    order_side,
+                    quote_currency_amount,
+                    quote_currency,
+                ),
+                Message=json.dumps(order, sort_keys=True, indent=4)
+            )
+            exit()
+
+        print("%s: Order %s still %s. Sleeping for %d (total %d)" % (
+            get_timestamp(),
+            order_id,
+            order["status"],
+            wait_time,
+            total_wait_time))
+        time.sleep(wait_time)
+        total_wait_time += wait_time
+        order = auth_client.get_order(order_id)
+        # print(json.dumps(order, sort_keys=True, indent=4))
+
+        if "message" in order and order["message"] == "NotFound":
+            # Most likely the order was manually cancelled in the UI
+            sns.publish(
+                TopicArn=sns_topic,
+                Subject="%s %s order of %s %s CANCELLED" % (
+                    market_name,
+                    order_side,
+                    quote_currency_amount,
+                    quote_currency,
+                ),
+                Message=json.dumps(result, sort_keys=True, indent=4)
+            )
+            exit()
+
+
+    # Order status is no longer pending!
+    # TODO: uncomment if market orders don't require a wait
+    sns.publish(
+        TopicArn=sns_topic,
+        Subject="%s %s market order of %s %s %s" % (
+            market_name,
+            order_side,
+            quote_currency_amount,
+            quote_currency,
+            order["status"],
+        ),
+        Message=json.dumps(order, sort_keys=True, indent=4)
+    )
+
+    offer_price = "TEST"
+    return (order, offer_price)
+
+
+
+"""
+    Basic Coinbase Pro DCA buy/sell bot that pulls the current market price, subtracts a
+        small spread to generate a valid price (see note below), then submits the trade as
+        a limit order. It can also make market orders.
+
+    This is meant to be run as a crontab to make regular buys/sells on a set schedule.
+"""
+parser = argparse.ArgumentParser(
+    description="""
+        This is a basic Coinbase Pro DCA buying/selling bot.
+
+        ex:
+            BTC-USD BUY 14 USD          (buy $14 worth of BTC)
+            BTC-USD BUY 0.00125 BTC     (buy 0.00125 BTC)
+            ETH-BTC SELL 0.00125 BTC    (sell 0.00125 BTC worth of ETH)
+            ETH-BTC SELL 0.1 ETH        (sell 0.1 ETH)
+    """,
+    formatter_class=argparse.RawTextHelpFormatter
+)
+
+# Required positional arguments
+parser.add_argument('market_name', help="(e.g. BTC-USD, ETH-BTC, etc)")
+
+parser.add_argument('order_side',
+                    type=str,
+                    choices=["BUY", "SELL"])
+
+parser.add_argument('amount',
+                    type=Decimal,
+                    help="The quantity to buy or sell in the amount_currency")
+
+parser.add_argument('amount_currency',
+                    help="The currency the amount is denominated in")
+
+
+# Additional options
+parser.add_argument('-sandbox',
+                    action="store_true",
+                    default=False,
+                    dest="sandbox_mode",
+                    help="Run against sandbox, skips user confirmation prompt")
+
+parser.add_argument('-warn_after',
+                    default=3600,
+                    action="store",
+                    type=int,
+                    dest="warn_after",
+                    help="secs to wait before sending an alert that an order isn't done")
+
+parser.add_argument('-j', '--job',
+                    action="store_true",
+                    default=False,
+                    dest="job_mode",
+                    help="Suppresses user confirmation prompt")
+
+parser.add_argument('-c', '--config',
+                    default="settings.conf",
+                    dest="config_file",
+                    help="Override default config file location")
+
+parser.add_argument('-m', '--market-order',
+                    action="store_true",
+                    default=False,
+                    help="Use a market order instead of the midpoint limit order."
+)
+
+def main(parser):
+    args = parser.parse_args()
+    print("%s: STARTED: %s" % (get_timestamp(), args))
+
+    market_name = args.market_name
+    order_side = args.order_side.lower()
+    amount = args.amount
+    amount_currency = args.amount_currency
+
+    sandbox_mode = args.sandbox_mode
+    job_mode = args.job_mode
+    warn_after = args.warn_after
+    market_order = args.market_order
+
+    if not sandbox_mode and not job_mode:
+        if sys.version_info[0] < 3:
+            # python2.x compatibility
+            response = raw_input("Production purchase! Confirm [Y]: ")  # noqa: F821
+        else:
+            response = input("Production purchase! Confirm [Y]: ")
+        if response != 'Y':
+            print("Exiting without submitting purchase.")
+            exit()
+
+    # Read settings
+    config = configparser.ConfigParser()
+    config.read(args.config_file)
+
+    config_section = 'production'
+    if sandbox_mode:
+        config_section = 'sandbox'
+    key = config.get(config_section, 'API_KEY')
+    passphrase = config.get(config_section, 'PASSPHRASE')
+    secret = config.get(config_section, 'SECRET_KEY')
+    aws_access_key_id = config.get(config_section, 'AWS_ACCESS_KEY_ID')
+    aws_secret_access_key = config.get(config_section, 'AWS_SECRET_ACCESS_KEY')
+    sns_topic = config.get(config_section, 'SNS_TOPIC')
+    aws_region = config.get(config_section, 'AWS_REGION')
+
+    # Instantiate public and auth API clients
+    if not args.sandbox_mode:
+        auth_client = gdax.AuthenticatedClient(key, secret, passphrase)
+    else:
+        # Use the sandbox API (requires a different set of API access credentials)
+        auth_client = gdax.AuthenticatedClient(
+            key,
+            secret,
+            passphrase,
+            api_url="https://api-public.sandbox.pro.coinbase.com")
+
+    public_client = gdax.PublicClient()
+
+    # Retrieve dict list of all trading pairs
+    products = public_client.get_products()
+    base_min_size = None
+    base_increment = None
+    quote_increment = None
+    for product in products:
+        if product.get("id") == market_name:
+            base_currency = product.get("base_currency")
+            quote_currency = product.get("quote_currency")
+            base_min_size = Decimal(product.get("base_min_size")).normalize()
+            base_increment = Decimal(product.get("base_increment")).normalize()
+            quote_increment = Decimal(product.get("quote_increment")).normalize()
+            if amount_currency == product.get("quote_currency"):
+                amount_currency_is_quote_currency = True
+            elif amount_currency == product.get("base_currency"):
+                amount_currency_is_quote_currency = False
+            else:
+                raise Exception("amount_currency %s not in market %s" % (amount_currency,
+                                                                         market_name))
+            print(product)
+
+    print("base_min_size: %s" % base_min_size)
+    print("quote_increment: %s" % quote_increment)
+
+    # Prep boto SNS client for email notifications
+    sns = boto3.client(
+        "sns",
+        aws_access_key_id=aws_access_key_id,
+        aws_secret_access_key=aws_secret_access_key,
+        region_name=aws_region
+    )
+
+    if market_order:
+        (order, offer_price) = do_market_order(
+            order_side,
+            auth_client,
+            amount,
+            quote_currency,
+            market_name,
+            sns, sns_topic,
+            warn_after
+        )
+    else:
+        (order, offer_price) = do_limit_order(
+                market_name,
+                public_client, 
+                auth_client,
+                sns, sns_topic,
+                amount_currency_is_quote_currency,
+                order_side,
+                quote_increment,
+                quote_currency,
+                base_increment,
+                base_currency,
+                amount,
+                amount_currency,
+                warn_after
+        )
+
     print("%s: DONE: %s %s order of %s %s %s @ %s %s" % (
         get_timestamp(),
         market_name,
@@ -361,3 +525,7 @@ if __name__ == "__main__":
         order["status"],
         offer_price,
         quote_currency))
+
+
+if __name__ == "__main__":
+    main(parser)

--- a/gdax_bot.py
+++ b/gdax_bot.py
@@ -118,6 +118,7 @@ if __name__ == "__main__":
     aws_access_key_id = config.get(config_section, 'AWS_ACCESS_KEY_ID')
     aws_secret_access_key = config.get(config_section, 'AWS_SECRET_ACCESS_KEY')
     sns_topic = config.get(config_section, 'SNS_TOPIC')
+    aws_region = config.get(config_section, 'AWS_REGION')
 
     # Instantiate public and auth API clients
     if not args.sandbox_mode:
@@ -161,7 +162,7 @@ if __name__ == "__main__":
         "sns",
         aws_access_key_id=aws_access_key_id,
         aws_secret_access_key=aws_secret_access_key,
-        region_name="us-east-1"     # N. Virginia
+        region_name=aws_region
     )
 
 

--- a/settings.conf.example
+++ b/settings.conf.example
@@ -5,7 +5,7 @@ SECRET_KEY = your_gdax_sandbox_secret_key
 SNS_TOPIC = your_aws_sns_topic_arn
 AWS_ACCESS_KEY_ID = your_aws_access_key_id
 AWS_SECRET_ACCESS_KEY = your_aws_secret_access_key
-
+AWS_REGION = us-east-1
 
 [production]
 PASSPHRASE = your_gdax_api_passphrase
@@ -14,7 +14,7 @@ SECRET_KEY = your_gdax_secret_key
 SNS_TOPIC = your_aws_sns_topic_arn
 AWS_ACCESS_KEY_ID = your_aws_access_key_id
 AWS_SECRET_ACCESS_KEY = your_aws_secret_access_key
-
+AWS_REGION = us-east-1
 
 [smallest_units]
 BTC = 0.00000001


### PR DESCRIPTION
Hi - thanks for making this script, it's really cool and I'm in the process of setting it up for personal use. One obstacle I've encountered is that Coinbase has significantly higher minimum order sizes for limit orders instead of market orders. I also don't care too much about slippage and more about being able to DCA at the finest amounts possible, so I tried to implement market orders. This is still WIP and I'm not positive it works yet because the sandbox doesn't have a lot of order activity on it.

I also made the AWS region a parameter in the config file.

Again, due to the magnitude of this change feel absolutely free not to use it, just thought I'd give back in case you do want to merge it in when it's ready.